### PR TITLE
Add always rounding up functionality

### DIFF
--- a/python/math_round.py
+++ b/python/math_round.py
@@ -1,0 +1,12 @@
+import math
+import numpy as np
+
+def np_round_up(x):
+    if type(x) is np.ndarray:
+        floor_mask = x - np.floor(x) < 0.5
+        z = np.where(floor_mask,np.floor(x),np.ceil(x))
+        return z.astype(dtype=np.int)
+    else:
+        if x - math.floor(x) < 0.5:
+            return math.floor(x)
+        return math.ceil(x)


### PR DESCRIPTION
For float values of the type x.5, this round function will always round up to (x+1).
Works for both scalar values and N-dimensional numpy arrays / matrices.